### PR TITLE
Update `ADMIN_IP` to `ADMIN_IP_ADDRESSES` in env.rb.example

### DIFF
--- a/config/env.rb.example
+++ b/config/env.rb.example
@@ -1,5 +1,5 @@
 # application
-ENV["ADMIN_IP"] = "127.0.0.1"
+ENV["ADMIN_IP_ADDRESSES"] = "127.0.0.1"
 # gmail
 ENV["GMAIL_USERNAME"] = "gmail-username@gmail.com"
 ENV["GMAIL_PASSWORD"] = "gmail-password"


### PR DESCRIPTION
I noticed the old variable didn’t seem to work anymore. 